### PR TITLE
Statement's `execute()` fix

### DIFF
--- a/src/Connection/Statement.php
+++ b/src/Connection/Statement.php
@@ -23,7 +23,7 @@ class Statement
 
     public function execute(array $inputParameters = array())
     {
-        $res = $this->stmt->execute($inputParameters);
+        $res = $this->stmt->execute(empty($inputParameters) ? null : $inputParameters);
         Flux::$numberOfQueries++;
         if ((int)$this->stmt->errorCode()) {
             $info = $this->stmt->errorInfo();


### PR DESCRIPTION
from https://github.com/rathena/FluxCP/commit/eebfb50b12de90af692c98b064cd49f2085b7ca9